### PR TITLE
Adding market to all event broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ const binance = new ccxws.Binance();
 
 // market could be from CCXT or genearted by the user
 const market = {
-  id: "ADABTC", // remote_id used by the exchange
-  base: "ADA", // standardized base symbol for Cardano
-  quote: "BTC", // standardized quote symbol for Bitcoin
+  id: "BTCUSDT", // remote_id used by the exchange
+  base: "BTC", // standardized base symbol for Cardano
+  quote: "USDT", // standardized quote symbol for Bitcoin
 };
 
 // handle trade events
@@ -118,22 +118,24 @@ Subscribe to events by addding an event handler to the client `.on(<event>)` met
 
 Once an event handler is attached you can start the stream using the `subscribe<X>` methods.
 
+All events emit the market used to subscribe to the event as a second property of the event handler.
+
 ```javascript
-binance.on("trades", trade => console.log(trade));
-binance.on("l2snapshot", snapshot => console.log(snapshot));
+binance.on("trades", (trade, market) => console.log(trade, market));
+binance.on("l2snapshot", (snapshot, market) => console.log(snapshot, market));
 ```
 
 ##### `ticker: Ticker`
 
-Fired when a ticker update is received. Returns an instance of `Ticker`.
+Fired when a ticker update is received. Returns an instance of `Ticker` and the `Market` used to subscribe to the event.
 
 ##### `trade: Trade`
 
-Fired when a trade is received. Returns an instance of `Trade`.
+Fired when a trade is received. Returns an instance of `Trade` and the `Market` used to subscribe to the event.
 
 ##### `l2snapshot: Level2Snapshot`
 
-Fired when a orderbook level 2 snapshot is received. Returns an instance of `Level2Snapshot`.
+Fired when a orderbook level 2 snapshot is received. Returns an instance of `Level2Snapshot` and the `Market` used to subscribe to the event.
 
 The level of detail will depend on the specific exchange and may include 5/10/20/50/100/1000 bids and asks.
 
@@ -141,17 +143,17 @@ This event is also fired when subscribing to the `l2update` event on many exchan
 
 ##### `l2update: Level2Update`
 
-Fired when a orderbook level 2 update is recieved. Returns an instance of `Level2Update`.
+Fired when a orderbook level 2 update is recieved. Returns an instance of `Level2Update` and the `Market` used to subscribe to the event.
 
 Subscribing to this event may trigger an initial `l2snapshot` event for many exchanges.
 
 ##### `l3snapshot: Level3Snapshot`
 
-Fired when a orderbook level 3 snapshot is received. Returns an instance of `Level3Snapshot`.
+Fired when a orderbook level 3 snapshot is received. Returns an instance of `Level3Snapshot` and the `Market` used to subscribe to the event.
 
 ##### `l3update: Level3Update` - orderbook level 3 Update
 
-Fired when a level 3 update is recieved. Returns an instance of `Level3Update`.
+Fired when a level 3 update is recieved. Returns an instance of `Level3Update` and the `Market` used to subscribe to the event.
 
 #### Connection Events
 

--- a/src/basic-multiclient.js
+++ b/src/basic-multiclient.js
@@ -124,8 +124,8 @@ class BasicMultiClient extends EventEmitter {
       if (marketObjectType === MarketObjectTypes.ticker) {
         let subscribed = client.subscribeTicker(market);
         if (subscribed) {
-          client.on("ticker", ticker => {
-            this.emit("ticker", ticker);
+          client.on("ticker", (ticker, market) => {
+            this.emit("ticker", ticker, market);
           });
         }
       }
@@ -133,8 +133,8 @@ class BasicMultiClient extends EventEmitter {
       if (marketObjectType === MarketObjectTypes.trade) {
         let subscribed = client.subscribeTrades(market);
         if (subscribed) {
-          client.on("trade", trade => {
-            this.emit("trade", trade);
+          client.on("trade", (trade, market) => {
+            this.emit("trade", trade, market);
           });
         }
       }
@@ -142,11 +142,11 @@ class BasicMultiClient extends EventEmitter {
       if (marketObjectType === MarketObjectTypes.level2update) {
         let subscribed = client.subscribeLevel2Updates(market);
         if (subscribed) {
-          client.on("l2update", l2update => {
-            this.emit("l2update", l2update);
+          client.on("l2update", (l2update, market) => {
+            this.emit("l2update", l2update, market);
           });
-          client.on("l2snapshot", l2snapshot => {
-            this.emit("l2snapshot", l2snapshot);
+          client.on("l2snapshot", (l2snapshot, market) => {
+            this.emit("l2snapshot", l2snapshot, market);
           });
         }
       }
@@ -154,8 +154,8 @@ class BasicMultiClient extends EventEmitter {
       if (marketObjectType === MarketObjectTypes.level2snapshot) {
         let subscribed = client.subscribeLevel2Snapshots(market);
         if (subscribed) {
-          client.on("l2snapshot", l2snapshot => {
-            this.emit("l2snapshot", l2snapshot);
+          client.on("l2snapshot", (l2snapshot, market) => {
+            this.emit("l2snapshot", l2snapshot, market);
           });
         }
       }

--- a/src/exchanges/bibox-client.spec.js
+++ b/src/exchanges/bibox-client.spec.js
@@ -45,7 +45,9 @@ describe("BiboxClient", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market1);
-    client.on("ticker", ticker => {
+    client.on("ticker", (ticker, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTC_USDT|ETH_BTC/);
       expect(ticker.fullId).toMatch(/Bibox:BTC\/USDT/);
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -83,7 +85,9 @@ describe("BiboxClient", () => {
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market1);
     client.subscribeTrades(market2);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTC_USDT|ETH_BTC/);
       expect(trade.fullId).toMatch(/Bibox:BTC\/USDT|Bibox:ETH\/BTC/);
       expect(trade.exchange).toMatch("Bibox");
       expect(trade.base).toMatch(/BTC|ETH/);
@@ -104,7 +108,9 @@ describe("BiboxClient", () => {
 
   test("should subscribe and emit level2 snapshots", done => {
     client.subscribeLevel2Snapshots(market1);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTC_USDT|ETH_BTC/);
       expect(snapshot.fullId).toMatch(/Bibox:BTC\/USDT/);
       expect(snapshot.exchange).toMatch("Bibox");
       expect(snapshot.base).toMatch(market1.base);

--- a/src/exchanges/binance-client.js
+++ b/src/exchanges/binance-client.js
@@ -170,42 +170,54 @@ class BinanceClient extends EventEmitter {
     // ticker
     if (msg.stream === "!ticker@arr") {
       for (let raw of msg.data) {
-        if (this._tickerSubs.has(raw.s.toLowerCase())) {
-          let ticker = this._constructTicker(raw);
-          this.emit("ticker", ticker);
-          return;
-        }
+        let remote_id = raw.s.toLowerCase();
+        let market = this._tickerSubs.get(remote_id);
+        if (!market) continue;
+
+        let ticker = this._constructTicker(raw, market);
+        this.emit("ticker", ticker, market);
       }
     }
 
     // trades
     if (msg.stream.toLowerCase().endsWith("trade")) {
-      let trade = this.useAggTrades ? this._constructAggTrade(msg) : this._constructRawTrade(msg);
-      this.emit("trade", trade);
+      let remote_id = msg.data.s.toLowerCase();
+      let market = this._tradeSubs.get(remote_id);
+      if (!market) return;
+
+      let trade = this.useAggTrades
+        ? this._constructAggTrade(msg, market)
+        : this._constructRawTrade(msg, market);
+      this.emit("trade", trade, market);
       return;
     }
 
     // l2snapshot
     if (msg.stream.endsWith("depth20")) {
-      let snapshot = this._constructLevel2Snapshot(msg);
-      this.emit("l2snapshot", snapshot);
+      let remote_id = msg.stream.split("@")[0];
+      let market = this._level2SnapshotSubs.get(remote_id);
+      if (!market) return;
+
+      let snapshot = this._constructLevel2Snapshot(msg, market);
+      this.emit("l2snapshot", snapshot, market);
       return;
     }
 
     // l2update
     if (msg.stream.endsWith("depth")) {
-      let update = this._constructLevel2Update(msg);
-      this.emit("l2update", update);
+      let remote_id = msg.stream.split("@")[0];
+      let market = this._level2UpdateSubs.get(remote_id);
+      if (!market) return;
+
+      let update = this._constructLevel2Update(msg, market);
+      this.emit("l2update", update, market);
       return;
     }
-
-    console.log(msg);
   }
 
-  _constructTicker(msg) {
+  _constructTicker(msg, market) {
     let {
       E: timestamp,
-      s: symbol,
       c: last,
       v: volume,
       q: quoteVolume,
@@ -218,7 +230,6 @@ class BinanceClient extends EventEmitter {
       b: bid,
       B: bidVolume,
     } = msg;
-    let market = this._tickerSubs.get(symbol.toLowerCase());
     let open = parseFloat(last) + parseFloat(change);
     return new Ticker({
       exchange: "Binance",
@@ -240,9 +251,8 @@ class BinanceClient extends EventEmitter {
     });
   }
 
-  _constructAggTrade({ data }) {
-    let { s: symbol, a: trade_id, p: price, q: size, T: time, m: buyer } = data;
-    let market = this._tradeSubs.get(symbol.toLowerCase());
+  _constructAggTrade({ data }, market) {
+    let { a: trade_id, p: price, q: size, T: time, m: buyer } = data;
     let unix = time;
     let amount = size;
     let side = buyer ? "buy" : "sell";
@@ -258,18 +268,8 @@ class BinanceClient extends EventEmitter {
     });
   }
 
-  _constructRawTrade({ data }) {
-    let {
-      s: symbol,
-      t: trade_id,
-      p: price,
-      q: size,
-      b: buyOrderId,
-      a: sellOrderId,
-      T: time,
-      m: buyer,
-    } = data;
-    let market = this._tradeSubs.get(symbol.toLowerCase());
+  _constructRawTrade({ data }, market) {
+    let { t: trade_id, p: price, q: size, b: buyOrderId, a: sellOrderId, T: time, m: buyer } = data;
     let unix = time;
     let amount = size;
     let side = buyer ? "buy" : "sell";
@@ -287,9 +287,7 @@ class BinanceClient extends EventEmitter {
     });
   }
 
-  _constructLevel2Snapshot(msg) {
-    let remote_id = msg.stream.split("@")[0];
-    let market = this._level2SnapshotSubs.get(remote_id);
+  _constructLevel2Snapshot(msg, market) {
     let sequenceId = msg.data.lastUpdateId;
     let asks = msg.data.asks.map(p => new Level2Point(p[0], p[1]));
     let bids = msg.data.bids.map(p => new Level2Point(p[0], p[1]));
@@ -303,9 +301,7 @@ class BinanceClient extends EventEmitter {
     });
   }
 
-  _constructLevel2Update(msg) {
-    let remote_id = msg.data.s.toLowerCase();
-    let market = this._level2UpdateSubs.get(remote_id);
+  _constructLevel2Update(msg, market) {
     let sequenceId = msg.data.U;
     let lastSequenceId = msg.data.u;
     let asks = msg.data.a.map(p => new Level2Point(p[0], p[1]));
@@ -348,7 +344,7 @@ class BinanceClient extends EventEmitter {
           asks,
           bids,
         });
-        this.emit("l2snapshot", snapshot);
+        this.emit("l2snapshot", snapshot, market);
       } catch (ex) {
         winston.warn(`failed to fetch snapshot for ${market.id} - ${ex}`);
         failed = true;

--- a/src/exchanges/binance-client.spec.js
+++ b/src/exchanges/binance-client.spec.js
@@ -40,7 +40,9 @@ describe("BinanceClient", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market);
-    client.on("ticker", ticker => {
+    client.on("ticker", (ticker, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/ETHBTC/);
       expect(ticker.fullId).toMatch("Binance:ETH/BTC");
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -72,7 +74,9 @@ describe("BinanceClient", () => {
 
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/ETHBTC/);
       expect(trade.fullId).toMatch("Binance:ETH/BTC");
       expect(trade.exchange).toMatch("Binance");
       expect(trade.base).toMatch("ETH");
@@ -92,8 +96,10 @@ describe("BinanceClient", () => {
     let hasSnapshot = false;
     let hasUpdates = false;
     client.subscribeLevel2Updates(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
       hasSnapshot = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/ETHBTC/);
       expect(snapshot.fullId).toMatch("Binance:ETH/BTC");
       expect(snapshot.exchange).toMatch("Binance");
       expect(snapshot.base).toMatch("ETH");
@@ -108,8 +114,10 @@ describe("BinanceClient", () => {
       expect(snapshot.bids[0].count).toBeUndefined();
       if (hasSnapshot && hasUpdates) done();
     });
-    client.on("l2update", update => {
+    client.on("l2update", (update, market) => {
       hasUpdates = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/ETHBTC/);
       expect(update.fullId).toMatch("Binance:ETH/BTC");
       expect(update.exchange).toMatch("Binance");
       expect(update.base).toMatch("ETH");
@@ -130,7 +138,9 @@ describe("BinanceClient", () => {
 
   test("should subscribe and emit level2 snapshots", done => {
     client.subscribeLevel2Snapshots(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/ETHBTC/);
       expect(snapshot.fullId).toMatch("Binance:ETH/BTC");
       expect(snapshot.exchange).toMatch("Binance");
       expect(snapshot.base).toMatch("ETH");

--- a/src/exchanges/bitfinex-client.spec.js
+++ b/src/exchanges/bitfinex-client.spec.js
@@ -40,7 +40,9 @@ describe("BitfinexClient", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market);
-    client.on("ticker", ticker => {
+    client.on("ticker", (ticker, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSD/);
       expect(ticker.fullId).toMatch("Bitfinex:BTC/USD");
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -72,7 +74,9 @@ describe("BitfinexClient", () => {
 
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSD/);
       expect(trade.fullId).toMatch("Bitfinex:BTC/USD");
       expect(trade.exchange).toMatch("Bitfinex");
       expect(trade.base).toMatch("BTC");
@@ -91,8 +95,10 @@ describe("BitfinexClient", () => {
   test("should subscribe and emit level2 snapshot and updates", done => {
     let hasSnapshot = false;
     client.subscribeLevel2Updates(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
       hasSnapshot = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSD/);
       expect(snapshot.fullId).toMatch("Bitfinex:BTC/USD");
       expect(snapshot.exchange).toMatch("Bitfinex");
       expect(snapshot.base).toMatch("BTC");
@@ -106,7 +112,9 @@ describe("BitfinexClient", () => {
       expect(parseFloat(snapshot.bids[0].size)).toBeGreaterThanOrEqual(0);
       expect(parseFloat(snapshot.bids[0].count)).toBeGreaterThanOrEqual(0);
     });
-    client.on("l2update", update => {
+    client.on("l2update", (update, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSD/);
       expect(hasSnapshot).toBeTruthy();
       expect(update.fullId).toMatch("Bitfinex:BTC/USD");
       expect(update.exchange).toMatch("Bitfinex");
@@ -125,8 +133,10 @@ describe("BitfinexClient", () => {
   test("should subscribe and emit level3 snapshot and updates", done => {
     let hasSnapshot = false;
     client.subscribeLevel3Updates(market);
-    client.on("l3snapshot", snapshot => {
+    client.on("l3snapshot", (snapshot, market) => {
       hasSnapshot = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSD/);
       expect(snapshot.fullId).toMatch("Bitfinex:BTC/USD");
       expect(snapshot.exchange).toMatch("Bitfinex");
       expect(snapshot.base).toMatch("BTC");
@@ -140,7 +150,9 @@ describe("BitfinexClient", () => {
       expect(parseFloat(snapshot.bids[0].price)).toBeGreaterThanOrEqual(0);
       expect(parseFloat(snapshot.bids[0].size)).toBeGreaterThanOrEqual(0);
     });
-    client.on("l3update", update => {
+    client.on("l3update", (update, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSD/);
       expect(hasSnapshot).toBeTruthy();
       expect(update.fullId).toMatch("Bitfinex:BTC/USD");
       expect(update.exchange).toMatch("Bitfinex");

--- a/src/exchanges/bitflyer-client.spec.js
+++ b/src/exchanges/bitflyer-client.spec.js
@@ -36,7 +36,9 @@ describe("BitflyerClient", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market);
-    client.on("ticker", ticker => {
+    client.on("ticker", (ticker, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/FX_BTC_JPY/);
       expect(ticker.fullId).toMatch("bitFlyer:BTC/JPY");
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -63,7 +65,9 @@ describe("BitflyerClient", () => {
 
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/FX_BTC_JPY/);
       expect(trade.fullId).toMatch("bitFlyer:BTC/JPY");
       expect(trade.exchange).toMatch("bitFlyer");
       expect(trade.base).toMatch("BTC");
@@ -85,8 +89,10 @@ describe("BitflyerClient", () => {
     let hasSnapshot = true;
     let hasUpdate = true;
     client.subscribeLevel2Updates(market);
-    client.on("l2snapshot", update => {
+    client.on("l2snapshot", (update, market) => {
       hasSnapshot = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/FX_BTC_JPY/);
       expect(update.fullId).toMatch("bitFlyer:BTC/JPY");
       expect(update.exchange).toMatch("bitFlyer");
       expect(update.base).toMatch("BTC");
@@ -101,8 +107,10 @@ describe("BitflyerClient", () => {
       expect(point.count).toBeUndefined();
       if (hasSnapshot && hasUpdate) done();
     });
-    client.on("l2update", update => {
+    client.on("l2update", (update, market) => {
       hasUpdate = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/FX_BTC_JPY/);
       expect(update.fullId).toMatch("bitFlyer:BTC/JPY");
       expect(update.exchange).toMatch("bitFlyer");
       expect(update.base).toMatch("BTC");

--- a/src/exchanges/bitmex-client.spec.js
+++ b/src/exchanges/bitmex-client.spec.js
@@ -36,7 +36,9 @@ describe("BitmexClient", () => {
 
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/XBTUSD/);
       expect(trade.fullId).toMatch("BitMEX:BTC/USD");
       expect(trade.exchange).toMatch("BitMEX");
       expect(trade.base).toMatch("BTC");
@@ -65,8 +67,10 @@ describe("BitmexClient", () => {
     let hasInsert = false;
     let hasDelete = false;
     client.subscribeLevel2Updates(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
       hasSnapshot = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/XBTUSD/);
       expect(snapshot.fullId).toMatch("BitMEX:BTC/USD");
       expect(snapshot.exchange).toMatch("BitMEX");
       expect(snapshot.base).toMatch("BTC");
@@ -81,7 +85,9 @@ describe("BitmexClient", () => {
       expect(snapshot.bids[0].count).toBeUndefined();
       client.removeAllListeners("l2snapshot");
     });
-    client.on("l2update", update => {
+    client.on("l2update", (update, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/XBTUSD/);
       expect(update.fullId).toMatch("BitMEX:BTC/USD");
       expect(update.exchange).toMatch("BitMEX");
       expect(update.base).toMatch("BTC");

--- a/src/exchanges/bitstamp-client.js
+++ b/src/exchanges/bitstamp-client.js
@@ -185,7 +185,7 @@ class BitstampClient extends EventEmitter {
       buyOrderId: msg.buy_order_id,
       sellOrderId: msg.sell_order_id,
     });
-    this.emit("trade", trade);
+    this.emit("trade", trade, market);
   }
 
   _sendSubLevel2Snapshot(remote_id) {
@@ -234,7 +234,7 @@ class BitstampClient extends EventEmitter {
       asks,
     });
 
-    this.emit("l2snapshot", spot);
+    this.emit("l2snapshot", spot, market);
   }
 
   _sendSubLevel2Updates(remote_id) {
@@ -288,7 +288,7 @@ class BitstampClient extends EventEmitter {
       asks,
     });
 
-    this.emit("l2update", update);
+    this.emit("l2update", update, market);
   }
 
   _sendSubLevel3Updates(remote_id) {
@@ -336,7 +336,7 @@ class BitstampClient extends EventEmitter {
       bids,
     });
 
-    this.emit("l3update", update);
+    this.emit("l3update", update, market);
   }
 
   _requestLevel2Snapshots() {
@@ -368,7 +368,7 @@ class BitstampClient extends EventEmitter {
           asks,
           bids,
         });
-        this.emit("l2snapshot", snapshot);
+        this.emit("l2snapshot", snapshot, market);
       } catch (ex) {
         winston.warn(`failed to fetch snapshot for ${market.id} - ${ex}`);
         this._requestLevel2Snapshot(market);

--- a/src/exchanges/bitstamp-client.spec.js
+++ b/src/exchanges/bitstamp-client.spec.js
@@ -36,7 +36,9 @@ describe("BitstampClient", () => {
 
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btcusd/);
       expect(trade.fullId).toMatch("Bitstamp:BTC/USD");
       expect(trade.exchange).toMatch("Bitstamp");
       expect(trade.base).toMatch("BTC");
@@ -56,8 +58,10 @@ describe("BitstampClient", () => {
     let hasSnapshot = false;
     let hasUpdate = false;
     client.subscribeLevel2Updates(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
       hasSnapshot = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btcusd/);
       expect(snapshot.fullId).toMatch("Bitstamp:BTC/USD");
       expect(snapshot.exchange).toMatch("Bitstamp");
       expect(snapshot.base).toMatch("BTC");
@@ -72,8 +76,10 @@ describe("BitstampClient", () => {
       expect(snapshot.bids[0].count).toBeUndefined();
       if (hasSnapshot && hasUpdate) done();
     });
-    client.on("l2update", update => {
+    client.on("l2update", (update, market) => {
       hasUpdate = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btcusd/);
       expect(update.fullId).toMatch("Bitstamp:BTC/USD");
       expect(update.exchange).toMatch("Bitstamp");
       expect(update.base).toMatch("BTC");
@@ -90,7 +96,9 @@ describe("BitstampClient", () => {
 
   test("should subscribe and emit level2 snapshots", done => {
     client.subscribeLevel2Snapshots(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btcusd/);
       expect(snapshot.fullId).toMatch("Bitstamp:BTC/USD");
       expect(snapshot.exchange).toMatch("Bitstamp");
       expect(snapshot.base).toMatch("BTC");
@@ -109,7 +117,9 @@ describe("BitstampClient", () => {
 
   test("should subscribe and emit level3 updates", done => {
     client.subscribeLevel3Updates(market);
-    client.on("l3update", update => {
+    client.on("l3update", (update, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btcusd/);
       expect(update.fullId).toMatch("Bitstamp:BTC/USD");
       expect(update.exchange).toMatch("Bitstamp");
       expect(update.base).toMatch("BTC");

--- a/src/exchanges/bittrex-client.spec.js
+++ b/src/exchanges/bittrex-client.spec.js
@@ -52,7 +52,9 @@ describe("BittrexClient", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market);
-    client.on("ticker", ticker => {
+    client.on("ticker", (ticker, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/USDT-BTC|BTC-ETH|BTC-LTC/);
       expect(ticker.fullId).toMatch("Bittrex:BTC/USDT");
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -84,8 +86,10 @@ describe("BittrexClient", () => {
   test("should subscribe and emit level2 snapshot and updates", done => {
     let hasSnapshot = false;
     client.subscribeLevel2Updates(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
       hasSnapshot = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/USDT-BTC|BTC-ETH|BTC-LTC/);
       expect(snapshot.fullId).toMatch("Bittrex:BTC/USDT");
       expect(snapshot.exchange).toMatch("Bittrex");
       expect(snapshot.base).toMatch("BTC");
@@ -103,7 +107,9 @@ describe("BittrexClient", () => {
       expect(parseFloat(snapshot.bids[0].size)).toBeGreaterThanOrEqual(0);
       expect(snapshot.bids[0].count).toBeUndefined();
     });
-    client.on("l2update", update => {
+    client.on("l2update", (update, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/USDT-BTC|BTC-ETH|BTC-LTC/);
       expect(update.fullId).toMatch("Bittrex:BTC/USDT");
       expect(update.exchange).toMatch("Bittrex");
       expect(update.base).toMatch("BTC");
@@ -125,7 +131,9 @@ describe("BittrexClient", () => {
     client.subscribeTrades(market);
     client.subscribeTrades(market2);
     client.subscribeTrades(market3);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/USDT-BTC|BTC-ETH|BTC-LTC/);
       expect(trade.fullId).toMatch(/Bittrex:BTC\/USDT|Bittrex:ETH\/BTC|Bittrex:LTC\/BTC/);
       expect(trade.exchange).toMatch("Bittrex");
       expect(trade.base).toMatch(/BTC|ETH|LTC/);

--- a/src/exchanges/coinex-client.js
+++ b/src/exchanges/coinex-client.js
@@ -110,43 +110,40 @@ class CoinexSingleClient extends BasicClient {
 
     if (method === "state.update") {
       let marketId = Object.keys(params[0])[0];
+      let market = this._tickerSubs.get(marketId);
+      if (!market) return;
 
-      if (this._tickerSubs.has(marketId)) {
-        let market = this._tickerSubs.get(marketId);
-
-        let ticker = this._constructTicker(params[0][marketId], market);
-        this.emit("ticker", ticker);
-      }
+      let ticker = this._constructTicker(params[0][marketId], market);
+      this.emit("ticker", ticker, market);
+      return;
     }
 
     if (method === "deals.update") {
       let marketId = params[0];
+      let market = this._tradeSubs.get(marketId);
+      if (!market) return;
 
-      if (this._tradeSubs.has(marketId)) {
-        let market = this._tradeSubs.get(marketId);
-
-        params[1].reverse().forEach(t => {
-          let trade = this._constructTrade(t, market);
-          this.emit("trade", trade);
-        });
-      }
+      params[1].reverse().forEach(t => {
+        let trade = this._constructTrade(t, market);
+        this.emit("trade", trade, market);
+      });
+      return;
     }
 
     if (method === "depth.update") {
       let marketId = params[2];
+      let market = this._level2UpdateSubs.get(marketId);
+      if (!market) return;
 
-      if (this._level2UpdateSubs.has(marketId)) {
-        let market = this._level2UpdateSubs.get(marketId),
-          isLevel2Snapshot = params[0];
-
-        if (isLevel2Snapshot) {
-          let l2snapshot = this._constructLevel2Snapshot(params[1], market);
-          this.emit("l2snapshot", l2snapshot);
-        } else {
-          let l2update = this._constructLevel2Update(params[1], market);
-          this.emit("l2update", l2update);
-        }
+      let isLevel2Snapshot = params[0];
+      if (isLevel2Snapshot) {
+        let l2snapshot = this._constructLevel2Snapshot(params[1], market);
+        this.emit("l2snapshot", l2snapshot, market);
+      } else {
+        let l2update = this._constructLevel2Update(params[1], market);
+        this.emit("l2update", l2update, market);
       }
+      return;
     }
   }
 

--- a/src/exchanges/coinex-client.spec.js
+++ b/src/exchanges/coinex-client.spec.js
@@ -46,7 +46,9 @@ describe("CoinexClient", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market1);
-    client.on("ticker", function tickerHandler(ticker) {
+    client.on("ticker", function tickerHandler(ticker, market) {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSDT|LTCBTC/);
       expect(ticker.fullId).toMatch("Coinex:BTC/USDT");
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -83,7 +85,9 @@ describe("CoinexClient", () => {
 
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market1);
-    client.on("trade", function tradeHandler(trade) {
+    client.on("trade", function tradeHandler(trade, market) {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSDT|LTCBTC/);
       expect(trade.fullId).toMatch("Coinex:BTC/USDT");
       expect(trade.exchange).toMatch("Coinex");
       expect(trade.base).toMatch("BTC");
@@ -105,7 +109,9 @@ describe("CoinexClient", () => {
   test("should subscribe and emit level2 updates", done => {
     client.subscribeLevel2Updates(market1);
 
-    client.on("l2update", function level2UpdateHandler(update) {
+    client.on("l2update", function level2UpdateHandler(update, market) {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSDT|LTCBTC/);
       expect(update.fullId).toMatch("Coinex:BTC/USDT");
       expect(update.exchange).toMatch("Coinex");
       expect(update.base).toMatch("BTC");

--- a/src/exchanges/ethfinex-client.js
+++ b/src/exchanges/ethfinex-client.js
@@ -174,11 +174,10 @@ class EthfinexClient extends BasicClient {
       ask: ask.toFixed(8),
       askVolume: askSize.toFixed(8),
     });
-    this.emit("ticker", ticker);
+    this.emit("ticker", ticker, market);
   }
 
   _onTradeMessage(msg) {
-
     let [chanId, , , id, unix, price, amount] = msg;
     let remote_id = this._channels[chanId].pair;
     let market = this._tradeSubs.get(remote_id);
@@ -195,7 +194,7 @@ class EthfinexClient extends BasicClient {
       price,
       amount,
     });
-    this.emit("trade", trade);
+    this.emit("trade", trade, market);
   }
 
   _onLevel2Snapshot(msg) {
@@ -216,7 +215,7 @@ class EthfinexClient extends BasicClient {
       bids,
       asks,
     });
-    this.emit("l2snapshot", result);
+    this.emit("l2snapshot", result, market);
   }
 
   _onLevel2Update(msg) {
@@ -242,7 +241,7 @@ class EthfinexClient extends BasicClient {
       asks,
       bids,
     });
-    this.emit("l2update", update);
+    this.emit("l2update", update, market);
   }
 
   _onLevel3Snapshot(msg, channel) {
@@ -262,7 +261,7 @@ class EthfinexClient extends BasicClient {
       asks,
       bids,
     });
-    this.emit("l3snapshot", result);
+    this.emit("l3snapshot", result, market);
   }
 
   _onLevel3Update(msg, channel) {
@@ -282,7 +281,7 @@ class EthfinexClient extends BasicClient {
       asks,
       bids,
     });
-    this.emit("l3update", result);
+    this.emit("l3update", result, market);
   }
 }
 

--- a/src/exchanges/ethfinex-client.spec.js
+++ b/src/exchanges/ethfinex-client.spec.js
@@ -40,7 +40,9 @@ describe("EthfinexClient", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market);
-    client.on("ticker", ticker => {
+    client.on("ticker", (ticker, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSD/);
       expect(ticker.fullId).toMatch("Ethfinex:BTC/USD");
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -72,7 +74,9 @@ describe("EthfinexClient", () => {
 
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSD/);
       expect(trade.fullId).toMatch("Ethfinex:BTC/USD");
       expect(trade.exchange).toMatch("Ethfinex");
       expect(trade.base).toMatch("BTC");
@@ -91,8 +95,10 @@ describe("EthfinexClient", () => {
   test("should subscribe and emit level2 snapshot and updates", done => {
     let hasSnapshot = false;
     client.subscribeLevel2Updates(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
       hasSnapshot = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSD/);
       expect(snapshot.fullId).toMatch("Ethfinex:BTC/USD");
       expect(snapshot.exchange).toMatch("Ethfinex");
       expect(snapshot.base).toMatch("BTC");
@@ -106,7 +112,9 @@ describe("EthfinexClient", () => {
       expect(parseFloat(snapshot.bids[0].size)).toBeGreaterThanOrEqual(0);
       expect(parseFloat(snapshot.bids[0].count)).toBeGreaterThanOrEqual(0);
     });
-    client.on("l2update", update => {
+    client.on("l2update", (update, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSD/);
       expect(hasSnapshot).toBeTruthy();
       expect(update.fullId).toMatch("Ethfinex:BTC/USD");
       expect(update.exchange).toMatch("Ethfinex");
@@ -125,8 +133,10 @@ describe("EthfinexClient", () => {
   test("should subscribe and emit level3 snapshot and updates", done => {
     let hasSnapshot = false;
     client.subscribeLevel3Updates(market);
-    client.on("l3snapshot", snapshot => {
+    client.on("l3snapshot", (snapshot, market) => {
       hasSnapshot = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSD/);
       expect(snapshot.fullId).toMatch("Ethfinex:BTC/USD");
       expect(snapshot.exchange).toMatch("Ethfinex");
       expect(snapshot.base).toMatch("BTC");
@@ -140,7 +150,9 @@ describe("EthfinexClient", () => {
       expect(parseFloat(snapshot.bids[0].price)).toBeGreaterThanOrEqual(0);
       expect(parseFloat(snapshot.bids[0].size)).toBeGreaterThanOrEqual(0);
     });
-    client.on("l3update", update => {
+    client.on("l3update", (update, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTCUSD/);
       expect(hasSnapshot).toBeTruthy();
       expect(update.fullId).toMatch("Ethfinex:BTC/USD");
       expect(update.exchange).toMatch("Ethfinex");

--- a/src/exchanges/gateio-client.js
+++ b/src/exchanges/gateio-client.js
@@ -96,43 +96,41 @@ class GateioSingleClient extends BasicClient {
     if (!params) return;
 
     if (method === "ticker.update") {
-      //let marketId = Object.keys(params[0])[0];
       let marketId = params[0];
-      if (this._tickerSubs.has(marketId)) {
-        let market = this._tickerSubs.get(marketId);
+      let market = this._tickerSubs.get(marketId);
+      if (!market) return;
 
-        let ticker = this._constructTicker(params[1], market); //params[0][marketId] -> params[1]
-        this.emit("ticker", ticker);
-      }
+      let ticker = this._constructTicker(params[1], market); //params[0][marketId] -> params[1]
+      this.emit("ticker", ticker, market);
+      return;
     }
 
     if (method === "trades.update") {
       let marketId = params[0];
-      if (this._tradeSubs.has(marketId)) {
-        let market = this._tradeSubs.get(marketId);
+      let market = this._tradeSubs.get(marketId);
+      if (!market) return;
 
-        params[1].forEach(t => {
-          let trade = this._constructTrade(t, market);
-          this.emit("trade", trade);
-        });
-      }
+      params[1].forEach(t => {
+        let trade = this._constructTrade(t, market);
+        this.emit("trade", trade, market);
+      });
+      return;
     }
 
     if (method === "depth.update") {
       let marketId = params[2];
+      let market = this._level2UpdateSubs.get(marketId);
+      if (!market) return;
 
-      if (this._level2UpdateSubs.has(marketId)) {
-        let market = this._level2UpdateSubs.get(marketId),
-          isLevel2Snapshot = params[0];
-
-        if (isLevel2Snapshot) {
-          let l2snapshot = this._constructLevel2Snapshot(params[1], market);
-          this.emit("l2snapshot", l2snapshot);
-        } else {
-          let l2update = this._constructLevel2Update(params[1], market);
-          this.emit("l2update", l2update);
-        }
+      let isLevel2Snapshot = params[0];
+      if (isLevel2Snapshot) {
+        let l2snapshot = this._constructLevel2Snapshot(params[1], market);
+        this.emit("l2snapshot", l2snapshot, market);
+      } else {
+        let l2update = this._constructLevel2Update(params[1], market);
+        this.emit("l2update", l2update, market);
       }
+      return;
     }
   }
 

--- a/src/exchanges/gateio-client.spec.js
+++ b/src/exchanges/gateio-client.spec.js
@@ -46,7 +46,9 @@ describe("GateioClient", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market1);
-    client.on("ticker", function tickerHandler(ticker) {
+    client.on("ticker", function tickerHandler(ticker, market) {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTC_USDT|ETH_BTC/);
       expect(ticker.fullId).toMatch("Gateio:BTC/USDT");
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -84,7 +86,9 @@ describe("GateioClient", () => {
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market1);
     client.subscribeTrades(market2);
-    client.on("trade", function tradeHandler(trade) {
+    client.on("trade", function tradeHandler(trade, market) {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTC_USDT|ETH_BTC/);
       expect(trade.fullId).toMatch(/Gateio:BTC\/USDT|Gateio:ETH\/BTC/);
       expect(trade.exchange).toMatch("Gateio");
       expect(trade.base).toMatch(/BTC|ETH/);
@@ -107,7 +111,9 @@ describe("GateioClient", () => {
   test("should subscribe and emit level2 updates", done => {
     client.subscribeLevel2Updates(market1);
     let hasSnapshot = true;
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTC_USDT|ETH_BTC/);
       expect(snapshot.fullId).toMatch("Gateio:BTC/USDT");
       expect(snapshot.exchange).toMatch("Gateio");
       expect(snapshot.base).toMatch("BTC");
@@ -123,7 +129,9 @@ describe("GateioClient", () => {
       expect(parseFloat(snapshot.bids[0].size)).toBeGreaterThanOrEqual(0);
       hasSnapshot = true;
     });
-    client.on("l2update", function level2UpdateHandler(update) {
+    client.on("l2update", function level2UpdateHandler(update, market) {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/BTC_USDT|ETH_BTC/);
       expect(update.fullId).toMatch("Gateio:BTC/USDT");
       expect(update.exchange).toMatch("Gateio");
       expect(update.base).toMatch("BTC");

--- a/src/exchanges/gemini-client.js
+++ b/src/exchanges/gemini-client.js
@@ -195,8 +195,9 @@ class GeminiClient extends EventEmitter {
         let events = msg.events.filter(p => p.type === "trade" && /ask|bid/.test(p.makerSide));
         for (let event of events) {
           let trade = this._constructTrade(event, market, timestampms);
-          this.emit("trade", trade);
+          this.emit("trade", trade, market);
         }
+        return;
       }
 
       // process l2 updates
@@ -204,11 +205,12 @@ class GeminiClient extends EventEmitter {
         let updates = msg.events.filter(p => p.type === "change");
         if (socket_sequence === 0) {
           let snapshot = this._constructL2Snapshot(updates, market, eventId);
-          this.emit("l2snapshot", snapshot);
+          this.emit("l2snapshot", snapshot, market);
         } else {
           let update = this._constructL2Update(updates, market, eventId, timestampms);
-          this.emit("l2update", update);
+          this.emit("l2update", update, market);
         }
+        return;
       }
     }
   }
@@ -218,16 +220,19 @@ class GeminiClient extends EventEmitter {
     let price = event.price;
     let amount = event.amount;
 
-    return new Trade({
-      exchange: "Gemini",
-      base: market.base,
-      quote: market.quote,
-      tradeId: event.tid,
-      side,
-      unix: timestamp,
-      price,
-      amount,
-    });
+    return new Trade(
+      {
+        exchange: "Gemini",
+        base: market.base,
+        quote: market.quote,
+        tradeId: event.tid,
+        side,
+        unix: timestamp,
+        price,
+        amount,
+      },
+      market
+    );
   }
 
   _constructL2Snapshot(events, market, sequenceId) {
@@ -240,14 +245,17 @@ class GeminiClient extends EventEmitter {
       else bids.push(update);
     }
 
-    return new Level2Snapshot({
-      exchange: "Gemini",
-      base: market.base,
-      quote: market.quote,
-      sequenceId,
-      asks,
-      bids,
-    });
+    return new Level2Snapshot(
+      {
+        exchange: "Gemini",
+        base: market.base,
+        quote: market.quote,
+        sequenceId,
+        asks,
+        bids,
+      },
+      market
+    );
   }
 
   _constructL2Update(events, market, sequenceId, timestampMs) {
@@ -260,15 +268,18 @@ class GeminiClient extends EventEmitter {
       else bids.push(update);
     }
 
-    return new Level2Update({
-      exchange: "Gemini",
-      base: market.base,
-      quote: market.quote,
-      sequenceId,
-      timestampMs,
-      asks,
-      bids,
-    });
+    return new Level2Update(
+      {
+        exchange: "Gemini",
+        base: market.base,
+        quote: market.quote,
+        sequenceId,
+        timestampMs,
+        asks,
+        bids,
+      },
+      market
+    );
   }
 }
 

--- a/src/exchanges/gemini-client.js
+++ b/src/exchanges/gemini-client.js
@@ -220,19 +220,16 @@ class GeminiClient extends EventEmitter {
     let price = event.price;
     let amount = event.amount;
 
-    return new Trade(
-      {
-        exchange: "Gemini",
-        base: market.base,
-        quote: market.quote,
-        tradeId: event.tid,
-        side,
-        unix: timestamp,
-        price,
-        amount,
-      },
-      market
-    );
+    return new Trade({
+      exchange: "Gemini",
+      base: market.base,
+      quote: market.quote,
+      tradeId: event.tid,
+      side,
+      unix: timestamp,
+      price,
+      amount,
+    });
   }
 
   _constructL2Snapshot(events, market, sequenceId) {
@@ -245,17 +242,14 @@ class GeminiClient extends EventEmitter {
       else bids.push(update);
     }
 
-    return new Level2Snapshot(
-      {
-        exchange: "Gemini",
-        base: market.base,
-        quote: market.quote,
-        sequenceId,
-        asks,
-        bids,
-      },
-      market
-    );
+    return new Level2Snapshot({
+      exchange: "Gemini",
+      base: market.base,
+      quote: market.quote,
+      sequenceId,
+      asks,
+      bids,
+    });
   }
 
   _constructL2Update(events, market, sequenceId, timestampMs) {
@@ -268,18 +262,15 @@ class GeminiClient extends EventEmitter {
       else bids.push(update);
     }
 
-    return new Level2Update(
-      {
-        exchange: "Gemini",
-        base: market.base,
-        quote: market.quote,
-        sequenceId,
-        timestampMs,
-        asks,
-        bids,
-      },
-      market
-    );
+    return new Level2Update({
+      exchange: "Gemini",
+      base: market.base,
+      quote: market.quote,
+      sequenceId,
+      timestampMs,
+      asks,
+      bids,
+    });
   }
 }
 

--- a/src/exchanges/gemini-client.spec.js
+++ b/src/exchanges/gemini-client.spec.js
@@ -43,8 +43,10 @@ describe("GeminiClient", () => {
   test("should subscribe and emit level2 snapshot and updates", done => {
     let hasSnapshot = false;
     client.subscribeLevel2Updates(market1);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
       hasSnapshot = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btcusd|ethusd/);
       expect(snapshot.fullId).toMatch("Gemini:BTC/USD");
       expect(snapshot.exchange).toMatch("Gemini");
       expect(snapshot.base).toMatch("BTC");
@@ -58,7 +60,9 @@ describe("GeminiClient", () => {
       expect(parseFloat(snapshot.bids[0].size)).toBeGreaterThanOrEqual(0);
       expect(snapshot.bids[0].count).toBeUndefined();
     });
-    client.on("l2update", update => {
+    client.on("l2update", (update, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btcusd|ethusd/);
       expect(hasSnapshot).toBeTruthy();
       expect(update.fullId).toMatch("Gemini:BTC/USD");
       expect(update.exchange).toMatch("Gemini");
@@ -81,7 +85,9 @@ describe("GeminiClient", () => {
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market1);
     client.subscribeTrades(market2);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btcusd|ethusd/);
       expect(trade.fullId).toMatch(/Gemini:(BTC|ETH)\/USD/);
       expect(trade.exchange).toMatch("Gemini");
       expect(trade.base).toMatch(/ETH|BTC/);

--- a/src/exchanges/hitbtc-client.spec.js
+++ b/src/exchanges/hitbtc-client.spec.js
@@ -40,7 +40,9 @@ describe("HitBTC", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market);
-    client.on("ticker", ticker => {
+    client.on("ticker", (ticker, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/ETHBTC/);
       expect(ticker.fullId).toMatch("HitBTC:ETH/BTC");
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -71,7 +73,9 @@ describe("HitBTC", () => {
 
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/ETHBTC/);
       expect(trade.fullId).toMatch("HitBTC:ETH/BTC");
       expect(trade.exchange).toMatch("HitBTC");
       expect(trade.base).toMatch("ETH");
@@ -90,8 +94,10 @@ describe("HitBTC", () => {
   test("should subscribe and emit level2 snapshot and updates", done => {
     let hasSnapshot = false;
     client.subscribeLevel2Updates(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
       hasSnapshot = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/ETHBTC/);
       expect(snapshot.fullId).toMatch("HitBTC:ETH/BTC");
       expect(snapshot.exchange).toMatch("HitBTC");
       expect(snapshot.base).toMatch("ETH");
@@ -105,7 +111,9 @@ describe("HitBTC", () => {
       expect(parseFloat(snapshot.bids[0].size)).toBeGreaterThanOrEqual(0);
       expect(snapshot.bids[0].count).toBeUndefined();
     });
-    client.on("l2update", update => {
+    client.on("l2update", (update, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/ETHBTC/);
       expect(hasSnapshot).toBeTruthy();
       expect(update.fullId).toMatch("HitBTC:ETH/BTC");
       expect(update.exchange).toMatch("HitBTC");

--- a/src/exchanges/huobi-client.spec.js
+++ b/src/exchanges/huobi-client.spec.js
@@ -91,7 +91,9 @@ describe("HuobiClient", () => {
 
   test("should subscribe and emit level2 snapshots", done => {
     client.subscribeLevel2Snapshots(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btcusdt/);
       expect(snapshot.fullId).toMatch("Huobi:BTC/USDT");
       expect(snapshot.exchange).toMatch("Huobi");
       expect(snapshot.base).toMatch("BTC");

--- a/src/exchanges/huobi-client.spec.js
+++ b/src/exchanges/huobi-client.spec.js
@@ -40,7 +40,9 @@ describe("HuobiClient", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market);
-    client.on("ticker", ticker => {
+    client.on("ticker", (ticker, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btcusdt/);
       expect(ticker.fullId).toMatch("Huobi:BTC/USDT");
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -69,7 +71,9 @@ describe("HuobiClient", () => {
 
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btcusdt/);
       expect(trade.fullId).toMatch("Huobi:BTC/USDT");
       expect(trade.exchange).toMatch("Huobi");
       expect(trade.base).toMatch("BTC");

--- a/src/exchanges/kraken-client.spec.js
+++ b/src/exchanges/kraken-client.spec.js
@@ -55,7 +55,9 @@ describe("KrakenClient", () => {
 
       test("should subscribe and emit ticker events", done => {
         client.subscribeTicker(market1);
-        client.on("ticker", ticker => {
+        client.on("ticker", (ticker, market) => {
+          expect(market).toBeDefined();
+          expect(market.id).toMatch(/XXBTZEUR/);
           expect(ticker.fullId).toMatch("Kraken:" + market1.base + "/" + market1.quote);
           expect(ticker.timestamp).toBeGreaterThan(1531677480465);
           expect(typeof ticker.last).toBe("string");
@@ -93,7 +95,9 @@ describe("KrakenClient", () => {
 
       test("should subscribe and emit trade events", done => {
         client.subscribeTrades(market1);
-        client.on("trade", trade => {
+        client.on("trade", (trade, market) => {
+          expect(market).toBeDefined();
+          expect(market.id).toMatch(/XXBTZEUR/);
           expect(trade.fullId).toMatch("Kraken:" + market1.base + "/" + market1.quote);
           expect(trade.exchange).toMatch("Kraken");
           expect(trade.base).toMatch(market1.base);
@@ -127,7 +131,9 @@ describe("KrakenClient", () => {
           }
         }
 
-        client.on("l2snapshot", s => {
+        client.on("l2snapshot", (s, market) => {
+          expect(market).toBeDefined();
+          expect(market.id).toMatch(/XXBTZEUR/);
           expect(s.fullId).toBe("Kraken:BTC/EUR");
           expect(s.exchange).toBe("Kraken");
           expect(s.base).toBe("BTC");
@@ -146,7 +152,9 @@ describe("KrakenClient", () => {
           hasL2Snapshot = true;
           fin();
         });
-        client.on("l2update", u => {
+        client.on("l2update", (u, market) => {
+          expect(market).toBeDefined();
+          expect(market.id).toMatch(/XXBTZEUR/);
           expect(u.fullId).toBe("Kraken:BTC/EUR");
           expect(u.exchange).toBe("Kraken");
           expect(u.base).toBe("BTC");

--- a/src/exchanges/okex-client.spec.js
+++ b/src/exchanges/okex-client.spec.js
@@ -40,7 +40,9 @@ describe("OkEXClient", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market);
-    client.on("ticker", ticker => {
+    client.on("ticker", (ticker, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btc_usdt/);
       expect(ticker.fullId).toMatch("OKEx:BTC/USDT");
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -69,7 +71,9 @@ describe("OkEXClient", () => {
 
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btc_usdt/);
       expect(trade.fullId).toMatch("OKEx:BTC/USDT");
       expect(trade.exchange).toMatch("OKEx");
       expect(trade.base).toMatch("BTC");
@@ -88,8 +92,10 @@ describe("OkEXClient", () => {
   test("should subscribe and emit level2 updates", done => {
     let hasSnapshot = false;
     client.subscribeLevel2Updates(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
       hasSnapshot = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btc_usdt/);
       expect(snapshot.fullId).toMatch("OKEx:BTC/USDT");
       expect(snapshot.exchange).toMatch("OKEx");
       expect(snapshot.base).toMatch("BTC");
@@ -103,8 +109,10 @@ describe("OkEXClient", () => {
       expect(parseFloat(snapshot.bids[0].size)).toBeGreaterThanOrEqual(0);
       expect(snapshot.bids[0].count).toBeUndefined();
     });
-    client.on("l2update", update => {
+    client.on("l2update", (update, market) => {
       expect(hasSnapshot).toBeTruthy();
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btc_usdt/);
       expect(update.fullId).toMatch("OKEx:BTC/USD");
       expect(update.exchange).toMatch("OKEx");
       expect(update.base).toMatch("BTC");
@@ -121,7 +129,9 @@ describe("OkEXClient", () => {
 
   test("should subscribe and emit level2 snapshots", done => {
     client.subscribeLevel2Snapshots(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btc_usdt/);
       expect(snapshot.fullId).toMatch("OKEx:BTC/USDT");
       expect(snapshot.exchange).toMatch("OKEx");
       expect(snapshot.base).toMatch("BTC");

--- a/src/exchanges/poloniex-client.spec.js
+++ b/src/exchanges/poloniex-client.spec.js
@@ -45,7 +45,9 @@ describe("PoloniexClient", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market);
-    client.on("ticker", ticker => {
+    client.on("ticker", (ticker, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/USDT_BTC|BTC_ETH/);
       expect(ticker.fullId).toMatch("Poloniex:BTC/USDT");
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -78,8 +80,10 @@ describe("PoloniexClient", () => {
   test("should subscribe and emit level2 snapshot and updates", done => {
     let hasSnapshot = false;
     client.subscribeLevel2Updates(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
       hasSnapshot = true;
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/USDT_BTC|BTC_ETH/);
       expect(snapshot.fullId).toMatch("Poloniex:BTC/USDT");
       expect(snapshot.exchange).toMatch("Poloniex");
       expect(snapshot.base).toMatch("BTC");
@@ -93,7 +97,9 @@ describe("PoloniexClient", () => {
       expect(parseFloat(snapshot.bids[0].size)).toBeGreaterThanOrEqual(0);
       expect(snapshot.bids[0].count).toBeUndefined();
     });
-    client.on("l2update", update => {
+    client.on("l2update", (update, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/USDT_BTC|BTC_ETH/);
       expect(hasSnapshot).toBeTruthy();
       expect(update.fullId).toMatch("Poloniex:BTC/USDT");
       expect(update.exchange).toMatch("Poloniex");
@@ -112,7 +118,9 @@ describe("PoloniexClient", () => {
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market);
     client.subscribeTrades(market2);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/USDT_BTC|BTC_ETH/);
       expect(trade.fullId).toMatch(/Poloniex:BTC\/USDT|Poloniex:ETH\/BTC/);
       expect(trade.exchange).toMatch("Poloniex");
       expect(trade.base).toMatch(/BTC|ETH/);

--- a/src/exchanges/upbit-client.spec.js
+++ b/src/exchanges/upbit-client.spec.js
@@ -56,7 +56,9 @@ describe("UpbitClient", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market1);
-    client.on("ticker", ticker => {
+    client.on("ticker", (ticker, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/KRW-BTC|KRW-BTT/);
       expect(ticker.fullId).toMatch("Upbit:" + market1.base + "/" + market1.quote);
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -93,7 +95,9 @@ describe("UpbitClient", () => {
 
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market1);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/KRW-BTC|KRW-BTT/);
       expect(trade.fullId).toMatch("Upbit:" + market1.base + "/" + market1.quote);
       expect(trade.exchange).toMatch("Upbit");
       expect(trade.base).toMatch(market1.base);
@@ -119,7 +123,9 @@ describe("UpbitClient", () => {
 
   test("should subscribe and emit level2 snapshots", done => {
     client.subscribeLevel2Snapshots(market1);
-    client.on("l2snapshot", update => {
+    client.on("l2snapshot", (update, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/KRW-BTC|KRW-BTT/);
       expect(update.fullId).toMatch("Upbit:" + market1.base + "/" + market1.quote);
       expect(update.exchange).toMatch("Upbit");
       expect(update.base).toMatch(market1.base);

--- a/src/exchanges/zb-client.spec.js
+++ b/src/exchanges/zb-client.spec.js
@@ -40,7 +40,9 @@ describe("ZBClient", () => {
 
   test("should subscribe and emit ticker events", done => {
     client.subscribeTicker(market);
-    client.on("ticker", ticker => {
+    client.on("ticker", (ticker, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btc_usdt/);
       expect(ticker.fullId).toMatch("ZB:BTC/USDT");
       expect(ticker.timestamp).toBeGreaterThan(1531677480465);
       expect(typeof ticker.last).toBe("string");
@@ -65,7 +67,9 @@ describe("ZBClient", () => {
 
   test("should subscribe and emit trade events", done => {
     client.subscribeTrades(market);
-    client.on("trade", trade => {
+    client.on("trade", (trade, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btc_usdt/);
       expect(trade.fullId).toMatch("ZB:BTC/USDT");
       expect(trade.exchange).toMatch("ZB");
       expect(trade.base).toMatch("BTC");
@@ -83,7 +87,9 @@ describe("ZBClient", () => {
 
   test("should subscribe and emit level2 snapshots", done => {
     client.subscribeLevel2Snapshots(market);
-    client.on("l2snapshot", snapshot => {
+    client.on("l2snapshot", (snapshot, market) => {
+      expect(market).toBeDefined();
+      expect(market.id).toMatch(/btc_usdt/);
       expect(snapshot.fullId).toMatch("ZB:BTC/USDT");
       expect(snapshot.exchange).toMatch("ZB");
       expect(snapshot.base).toMatch("BTC");


### PR DESCRIPTION
This change adds the subscribing market as the second argument for event handlers. This is preferable to including the market in the primary event payload as it would add unnecessary properties to that object.

If a user wishes to receive the subscribe market for the event, they simply need to handle the second property:
```javascript
binance.on('trade', (trade, market) => {

});
```

- all markets were modified to support this behavior
- all markets now have test coverage to ensure the market event is supplied as the second argument.