### PR TITLE
Don't fetch snapshot again

### DIFF
--- a/src/exchanges/binance-client.js
+++ b/src/exchanges/binance-client.js
@@ -365,7 +365,6 @@ class BinanceClient extends EventEmitter {
 
   async _requestLevel2Snapshot(market) {
     this._restSem.take(async () => {
-      let failed = false;
       try {
         let remote_id = market.id;
         let uri = `https://api.binance.com/api/v1/depth?limit=1000&symbol=${remote_id}`;
@@ -384,11 +383,8 @@ class BinanceClient extends EventEmitter {
         this.emit("l2snapshot", snapshot, market);
       } catch (ex) {
         this.emit("error", ex);
-        failed = true;
       } finally {
-        await wait(this.REST_REQUEST_DELAY_MS);
         this._restSem.leave();
-        if (failed) this._requestLevel2Snapshot(market);
       }
     });
   }

--- a/src/exchanges/kucoin-client.js
+++ b/src/exchanges/kucoin-client.js
@@ -301,9 +301,8 @@ class KucoinClient extends BasicClient {
         });
         this.emit("l2snapshot", snapshot);
       } catch (ex) {
-        this._requestLevel2Snapshot(market);
+        this.emit("error", ex);
       } finally {
-        await wait(this.REST_REQUEST_DELAY_MS);
         this._sem.leave();
       }
     });


### PR DESCRIPTION
Fetching the snapshot on an error will lead to infinite loops
For example if a market doesn't exist it will return a 400 status code
Will keep looping forever