### PR TITLE
okex: changing port to 8443

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ccxws",
-  "version": "0.29.5",
+  "version": "0.29.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccxws",
-  "version": "0.29.5",
+  "version": "0.29.6",
   "description": "Websocket client for 20+ cryptocurrency exchanges",
   "keywords": [
     "bitmex",

--- a/src/exchanges/okex-client.js
+++ b/src/exchanges/okex-client.js
@@ -32,7 +32,7 @@ class OKExClient extends BasicClient {
    * Refer to: https://www.okex.com/docs/en/#spot_ws-checksum
    */
   constructor() {
-    super("wss://real.okex.com:10442/ws/v3", "OKEx");
+    super("wss://real.okex.com:8443/ws/v3", "OKEx");
     this.hasTickers = true;
     this.hasTrades = true;
     this.hasLevel2Snapshots = true;


### PR DESCRIPTION
Port change for V3 API has now changed to 8443 from 10442 as of
https://okexsupport.zendesk.com/hc/en-us/articles/360030824232-Change-in-V3-WebSocket-API-Address-Port-Number

Closes #138 