### PR TITLE
gemini emit ticker on every top of book, instead of every trade. kraken add spread feed

### DIFF
--- a/src/exchanges/gemini-client.js
+++ b/src/exchanges/gemini-client.js
@@ -304,8 +304,8 @@ class GeminiClient extends EventEmitter {
           if (event.type === "trade") {
             thisCachedTicker.last = event.price;
             thisCachedTicker.timestamp = msg.timestampms;
-            this.emit("ticker", this.tickersCache.get(marketId), market);
           }
+          this.emit("ticker", this.tickersCache.get(marketId), market);
         }
       }
     }


### PR DESCRIPTION
When I added Gemini ticker a few months ago it looks like I accidentally added a limitation to only emit ticker updates when a trade occurs. This changes it so that whenever top of book changes or an trade occurs it will emit a ticker event, making tickers live.

This also adds a "spread" feed for the Kraken client for live top of book updates. This isn't a standard API for ccxws but I tried to keep it conforming to the standards you've set.