### PR TITLE
gemini emit ticker on every top of book update, instead of every trade. kraken add spread feed #146

### DIFF
--- a/src/exchanges/gemini-client.js
+++ b/src/exchanges/gemini-client.js
@@ -301,11 +301,17 @@ class GeminiClient extends EventEmitter {
             thisCachedTicker.bid = event.price;
             thisCachedTicker.timestamp = msg.timestampms;
           }
+          
           if (event.type === "trade") {
             thisCachedTicker.last = event.price;
             thisCachedTicker.timestamp = msg.timestampms;
           }
-          this.emit("ticker", this.tickersCache.get(marketId), market);
+          // don't emit a partial ticker if we haven't received last, ask and bid yet.
+          // so it will wait for the first trade to arrive, that is when we receive
+          // the first "last" value
+          if (thisCachedTicker.last && thisCachedTicker.ask && thisCachedTicker.bid) {
+            this.emit("ticker", this.tickersCache.get(marketId), market);
+          }
         }
       }
     }

--- a/src/exchanges/gemini-client.js
+++ b/src/exchanges/gemini-client.js
@@ -301,17 +301,11 @@ class GeminiClient extends EventEmitter {
             thisCachedTicker.bid = event.price;
             thisCachedTicker.timestamp = msg.timestampms;
           }
-          
           if (event.type === "trade") {
             thisCachedTicker.last = event.price;
             thisCachedTicker.timestamp = msg.timestampms;
           }
-          // don't emit a partial ticker if we haven't received last, ask and bid yet.
-          // so it will wait for the first trade to arrive, that is when we receive
-          // the first "last" value
-          if (thisCachedTicker.last && thisCachedTicker.ask && thisCachedTicker.bid) {
-            this.emit("ticker", this.tickersCache.get(marketId), market);
-          }
+          this.emit("ticker", this.tickersCache.get(marketId), market);
         }
       }
     }

--- a/src/exchanges/gemini-client.js
+++ b/src/exchanges/gemini-client.js
@@ -304,8 +304,8 @@ class GeminiClient extends EventEmitter {
           if (event.type === "trade") {
             thisCachedTicker.last = event.price;
             thisCachedTicker.timestamp = msg.timestampms;
-            this.emit("ticker", this.tickersCache.get(marketId), market);
           }
+          this.emit("ticker", this.tickersCache.get(marketId), market);
         }
       }
     }

--- a/src/exchanges/kraken-client.js
+++ b/src/exchanges/kraken-client.js
@@ -352,8 +352,7 @@ class KrakenClient extends BasicClient {
       return;
     }
 
-    // tickers use the "spread" feed to get live updates on each top of book update. 
-    // we don't use the "tickers" feed because it only gets updates on every match (trade)
+    // use the "spread" feed to get live updates on each top of book update. 
     /*
       spread event example, they're a little different as it's just an array:
       [ 815,


### PR DESCRIPTION
for #142 

When I added Gemini ticker a few months ago it looks like I accidentally added a limitation to only emit ticker updates when a trade occurs. This changes it so that whenever top of book changes or a trade occurs it will emit a ticker event, making tickers live.

This also adds a "spread" feed for the Kraken client for live top of book updates. This isn't a standard API for ccxws but I tried to keep it conforming to the standards you've set.