### PR TITLE
Gemini emit ticker on every top of book update

### DIFF
--- a/src/exchanges/gemini-client.js
+++ b/src/exchanges/gemini-client.js
@@ -304,8 +304,8 @@ class GeminiClient extends EventEmitter {
           if (event.type === "trade") {
             thisCachedTicker.last = event.price;
             thisCachedTicker.timestamp = msg.timestampms;
-            this.emit("ticker", this.tickersCache.get(marketId), market);
           }
+          this.emit("ticker", this.tickersCache.get(marketId), market);
         }
       }
     }


### PR DESCRIPTION
Emit ticker event each time ask, bid or last changes, instead of only when a match occurs. This enables real-time top of book updates.