### PR TITLE
Incremental subscribe/unsubscribe on binance

### DIFF
--- a/__tests__/exchanges/binance-client.spec.js
+++ b/__tests__/exchanges/binance-client.spec.js
@@ -25,6 +25,7 @@ testClient({
   hasLevel2Updates: true,
   hasLevel3Snapshots: false,
   hasLevel3Updates: false,
+  hasIncrementalSubscribe: true,
 
   ticker: {
     hasTimestamp: true,

--- a/__tests__/test-runner.js
+++ b/__tests__/test-runner.js
@@ -61,14 +61,26 @@ function testClient(spec) {
 
     if (spec.hasLevel2Snapshots && spec.l2snapshot) {
       testLevel2Snapshots(spec, state);
+
+      if (spec.hasIncrementalSubscribe) {
+        testIncrementalLevel2Snapshots(spec, state);
+      }
     }
 
     if (spec.hasLevel2Updates && spec.l2update) {
       testLevel2Updates(spec, state);
+
+      if (spec.hasIncrementalSubscribe) {
+        testIncrementalLevel2Updates(spec, state);
+      }
     }
 
     if (spec.hasLevel3Updates && spec.l3update) {
       testLevel3Updates(spec, state);
+
+      if (spec.hasIncrementalSubscribe) {
+        testIncrementalLevel3Updates(spec, state);
+      }
     }
 
     describe("close", () => {
@@ -673,6 +685,112 @@ function testLevel3Result(spec, result, type) {
     expect(parseFloat(actual)).to.not.be.NaN;
   });
 }
+
+function testIncrementalLevel2Snapshots(spec, state) {
+  describe("subscribeLevel2SnapshotsIncrementally", () => {
+    let result = { closed: false };
+    let client;
+
+    before(() => {
+      client = state.client;
+    })
+
+    it("should subscribe and unsubscribe but not reconnect", done => {
+      for (let market of spec.markets) {
+        client.subscribeLevel2Snapshots(market);
+      }
+
+      client.on("closed", () => {
+        result.closed = true;
+      });
+
+      client.on('l2snapshot', () => {
+        for (let market of spec.markets) {
+          client.unsubscribeLevel2Snapshots(market);
+        }
+
+        expect(result.closed).to.be.false;
+        client.removeAllListeners("l2snapshot");
+        client.removeAllListeners("closed");
+        done();
+
+      })
+    })
+      .timeout(60000)
+      .retries(3);
+  })
+}
+
+function testIncrementalLevel2Updates(spec, state) {
+  describe("subscribeLevel2UpdatesIncrementally", () => {
+    let result = { closed: false };
+    let client;
+
+    before(() => {
+      client = state.client;
+    })
+
+    it("should subscribe and unsubscribe but not reconnect", done => {
+      for (let market of spec.markets) {
+        client.subscribeLevel2Updates(market);
+      }
+
+      client.on("closed", () => {
+        result.closed = true;
+      });
+
+      client.on('l2update', () => {
+        for (let market of spec.markets) {
+          client.unsubscribeLevel2Updates(market);
+        }
+
+        expect(result.closed).to.be.false;
+        client.removeAllListeners("l2update");
+        client.removeAllListeners("closed");
+        done();
+
+      })
+    })
+      .timeout(60000)
+      .retries(3);
+  })
+}
+
+function testIncrementalLevel3Updates(spec, state) {
+  describe("subscribeLevel3UpdatesIncrementally", () => {
+    let result = { closed: false };
+    let client;
+
+    before(() => {
+      client = state.client;
+    })
+
+    it("should subscribe and unsubscribe but not reconnect", done => {
+      for (let market of spec.markets) {
+        client.subscribeLevel3Updates(market);
+      }
+
+      client.on("closed", () => {
+        result.closed = true;
+      });
+
+      client.on('l3update', () => {
+        for (let market of spec.markets) {
+          client.unsubscribeLevel3Updates(market);
+        }
+
+        expect(result.closed).to.be.false;
+        client.removeAllListeners("l3update");
+        client.removeAllListeners("closed");
+        done();
+
+      })
+    })
+      .timeout(60000)
+      .retries(3);
+  })
+}
+
 
 //////////////////////////////////////////////////////
 

--- a/src/exchanges/binance-client.js
+++ b/src/exchanges/binance-client.js
@@ -118,6 +118,11 @@ class BinanceClient extends EventEmitter {
         map.set(remote_id, market);
         const newStreams = this._buildStreams();
         const subscribeStreams = newStreams.filter(stream => !oldStreams.includes(stream));
+
+        if (!subscribeStreams.length) {
+          return;
+        }
+
         const request = {
           method: "SUBSCRIBE",
           params: subscribeStreams,
@@ -148,6 +153,11 @@ class BinanceClient extends EventEmitter {
         map.delete(remote_id);
         const newStreams = this._buildStreams();
         const subscribeStreams = oldStreams.filter(stream => !newStreams.includes(stream));
+
+        if (!subscribeStreams.length) {
+          return;
+        }
+
         const request = {
           method: "UNSUBSCRIBE",
           params: subscribeStreams,


### PR DESCRIPTION
Hi, this adds subscribing/unsubscribing to binance streams without the reconnecting. The original reconnecting while subscribing/unsubscribing causes binance to close the websocket connection if done too fast, while this version allows you to subscribe/unsubscribe as fast you want.

Binance test spec still works ;)