### PR TITLE
flowcontrol: add check to unref

### DIFF
--- a/src/flowcontrol/batch.js
+++ b/src/flowcontrol/batch.js
@@ -24,7 +24,9 @@ class Batch {
 
   _schedule() {
     this._handle = setTimeout(this._process.bind(this), this.collectMs);
-    this._handle.unref();
+    if (this._handle.unref) {
+      this._handle.unref();
+    }
   }
 
   _process() {

--- a/src/flowcontrol/debounce.js
+++ b/src/flowcontrol/debounce.js
@@ -23,7 +23,9 @@ class Debounce {
 
   _schedule() {
     this._handle = setTimeout(this._process.bind(this), this.waitMs);
-    this._handle.unref();
+    if (this._handle.unref) {
+      this._handle.unref();
+    }
   }
 
   _process() {

--- a/src/flowcontrol/throttle.js
+++ b/src/flowcontrol/throttle.js
@@ -24,7 +24,9 @@ class Throttle {
 
   _schedule() {
     this._handle = setTimeout(this._process.bind(this), this.delayMs);
-    this._handle.unref();
+    if (this._handle.unref) {
+      this._handle.unref();
+    }
   }
 
   _process() {


### PR DESCRIPTION
This commit adds existance checks to the unref method calls of flowcontrol
timeouts.

Flow control methods use the unref method of timeouts to prevent flowcontrol
handles from keeping the process open. This feature was added in Node 0.9.1.

Fixes issue with #164 