### PR TITLE
Watcher: Call _markAlive on candle event

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -13,6 +13,7 @@ class Watcher {
 
     this._markAlive = this._markAlive.bind(this);
     client.on("ticker", this._markAlive);
+    client.on("candle", this._markAlive);
     client.on("trade", this._markAlive);
     client.on("l2snapshot", this._markAlive);
     client.on("l2update", this._markAlive);


### PR DESCRIPTION
Small fix: If you only subscribe to candle events, it doesn't update the last received message and always try to reconnect.