### PR TITLE
Huobi candle: volume from base asset

### DIFF
--- a/src/exchanges/huobi-base.js
+++ b/src/exchanges/huobi-base.js
@@ -242,7 +242,7 @@ class HuobiBase extends BasicClient {
       tick.high.toFixed(8),
       tick.low.toFixed(8),
       tick.close.toFixed(8),
-      tick.vol.toFixed(8)
+      tick.amount.toFixed(8)
     );
   }
 


### PR DESCRIPTION
https://huobiapi.github.io/docs/spot/v1/en/#market-candlestick

`.vol` is the volume of the quote asset. `.amount` is the correct volume here.