### PR TITLE
bitfinex use v2 api, sequence IDs

### DIFF
--- a/__tests__/exchanges/bitfinex-client.spec.js
+++ b/__tests__/exchanges/bitfinex-client.spec.js
@@ -57,27 +57,27 @@ testClient({
   },
 
   l2snapshot: {
-    hasTimestampMs: false,
+    hasTimestampMs: true,
     hasSequenceId: true,
     hasCount: true,
   },
 
   l2update: {
     hasSnapshot: true,
-    hasTimestampMs: false,
-    hasSequenceId: false,
+    hasTimestampMs: true,
+    hasSequenceId: true,
     hasCount: true,
   },
 
   l3snapshot: {
-    hasTimestampMs: false,
-    hasSequenceId: false,
+    hasTimestampMs: true,
+    hasSequenceId: true,
   },
 
   l3update: {
     hasSnapshot: true,
-    hasTimestampMs: false,
-    hasSequenceId: false,
+    hasTimestampMs: true,
+    hasSequenceId: true,
     hasCount: true,
   },
 });

--- a/__tests__/exchanges/bitfinex-client.spec.js
+++ b/__tests__/exchanges/bitfinex-client.spec.js
@@ -58,7 +58,7 @@ testClient({
 
   l2snapshot: {
     hasTimestampMs: false,
-    hasSequenceId: false,
+    hasSequenceId: true,
     hasCount: true,
   },
 

--- a/src/exchanges/bitfinex-client.js
+++ b/src/exchanges/bitfinex-client.js
@@ -30,7 +30,8 @@ class BitfinexClient extends BasicClient {
     // combine multiple flags by summing their values
     // 65536 adds a sequence ID to each message
     // 32768 adds a Timestamp in milliseconds to each received event
-    // 131072 Enable checksum for every book iteration. Checks the top 25 entries for each side of book. Checksum is a signed int. more info https://docs.bitfinex.com/docs/ws-websocket-checksum
+    // 131072 Enable checksum for every book iteration. Checks the top 25 entries for each side of book. Checksum is a signed int. more info https://docs.bitfinex.com/docs/ws-websocket-checksum. it's sent in its own
+    // separate event so we've disabled it
     this._wss.send(JSON.stringify({ event: 'conf', flags: 65536 + 32768 }));
   }
 

--- a/src/exchanges/bitfinex-client.js
+++ b/src/exchanges/bitfinex-client.js
@@ -219,6 +219,18 @@ class BitfinexClient extends BasicClient {
   }
 
   _onLevel2Snapshot(msg, market) {
+    /*
+    example msg: 
+      [
+        646750,
+        [ 
+          [ 31115, 1, 1 ],
+          [ 31114, 1, 0.31589592 ],
+          ...
+        ],
+        1
+      ]
+  */
     let bids = [];
     let asks = [];
     const sequence = +msg[2];
@@ -240,6 +252,7 @@ class BitfinexClient extends BasicClient {
   }
 
   _onLevel2Update(msg, market) {
+    // example msg: [ 646750, [ 30927, 5, 0.0908 ], 19 ]
     let [price, count, size] = msg[1];
     let sequence = +msg[2];
 
@@ -266,6 +279,18 @@ class BitfinexClient extends BasicClient {
   }
 
   _onLevel3Snapshot(msg, market) {
+    /*
+    example msg:
+    [
+      648087,
+      [ 
+        [ 55888179267, 31111, 0.05 ],
+        [ 55895806791, 31111, 0.989 ],
+        ...
+      ],
+      1
+    ]
+    */
     let bids = [];
     let asks = [];
     
@@ -289,10 +314,10 @@ class BitfinexClient extends BasicClient {
   }
 
   _onLevel3Update(msg, market) {
+    // example msg: [ 648087, [ 55895794256, 31107, 0.07799627 ], 4 ]
     let bids = [];
     let asks = [];
     
-    // let [price, count, size] = msg[1];
     let [orderId, price, size] = msg[1];
     let sequence = +msg[2];
 

--- a/src/exchanges/bitfinex-client.js
+++ b/src/exchanges/bitfinex-client.js
@@ -27,10 +27,11 @@ class BitfinexClient extends BasicClient {
   }
   _sendConfiguration() {
     // see docs for "conf" flags. https://docs.bitfinex.com/docs/ws-general#configuration
+    // combine multiple flags by summing their values
     // 65536 adds a sequence ID to each message
     // 32768 adds a Timestamp in milliseconds to each received event
     // 131072 Enable checksum for every book iteration. Checks the top 25 entries for each side of book. Checksum is a signed int. more info https://docs.bitfinex.com/docs/ws-websocket-checksum
-    this._wss.send(JSON.stringify({ event: 'conf', flags: 65536 + 32768 + 131072 }));
+    this._wss.send(JSON.stringify({ event: 'conf', flags: 65536 + 32768 }));
   }
 
 
@@ -128,11 +129,6 @@ class BitfinexClient extends BasicClient {
 
   _onMessage(raw) {
     let msg = JSON.parse(raw);
-    if (msg[1] === 'cs') {
-      // checksum msg
-      // ex: [ 20114, 'cs', 625400997, 116, 1609794565952 ]
-      return;
-    }
 
     // capture channel metadata
     if (msg.event === "subscribed") {

--- a/src/exchanges/bitfinex-client.js
+++ b/src/exchanges/bitfinex-client.js
@@ -217,7 +217,7 @@ class BitfinexClient extends BasicClient {
       base: market.base,
       quote: market.quote,
       tradeId: id.toFixed(),
-      unix: unix * 1000,
+      unix: unix,
       side,
       price,
       amount,
@@ -337,7 +337,7 @@ class BitfinexClient extends BasicClient {
     let sequence = Number(msg[2]);
     const timestampMs = msg[3];
 
-    let point = new Level3Point(orderId, price.toFixed(8), Math.abs(size).toFixed(8));
+    let point = new Level3Point(orderId.toFixed(), price.toFixed(8), Math.abs(size).toFixed(8));
     if (size > 0) bids.push(point);
     else asks.push(point);
 

--- a/src/exchanges/bitfinex-client.js
+++ b/src/exchanges/bitfinex-client.js
@@ -66,16 +66,14 @@ class BitfinexClient extends BasicClient {
   }
 
   _sendSubLevel2Updates(remote_id) {
-    setTimeout(() => {
-      this._wss.send(
-        JSON.stringify({
-          event: "subscribe",
-          channel: "book",
-          pair: remote_id,
-          len: "250"
-        })
-      );
-    }, 2000)
+    this._wss.send(
+      JSON.stringify({
+        event: "subscribe",
+        channel: "book",
+        pair: remote_id,
+        len: "250"
+      })
+    );
   }
 
   _sendUnsubLevel2Updates(remote_id) {
@@ -125,7 +123,6 @@ class BitfinexClient extends BasicClient {
 
   _onMessage(raw) {
     let msg = JSON.parse(raw);
-    console.log('got msg', msg);
 
     // capture channel metadata
     if (msg.event === "subscribed") {
@@ -138,9 +135,7 @@ class BitfinexClient extends BasicClient {
     if (!channel) return;
 
     // ignore heartbeats
-    if (msg[1] === "hb") {
-      return;
-    };
+    if (msg[1] === "hb") return;
 
     if (channel.channel === "ticker") {
       let market = this._tickerSubs.get(channel.pair);

--- a/src/exchanges/bitfinex-client.js
+++ b/src/exchanges/bitfinex-client.js
@@ -25,7 +25,7 @@ class BitfinexClient extends BasicClient {
         hasSentConfig = true;
         // see docs for "conf" flags. https://docs.bitfinex.com/docs/ws-general#configuration
         // 65536 adds a sequence ID to each message
-        this._wss.send(JSON.stringify({ event: 'conf', flags: 65536 }))
+        this._wss.send(JSON.stringify({ event: 'conf', flags: 65536 }));
       }
     });
   }
@@ -240,7 +240,6 @@ class BitfinexClient extends BasicClient {
   }
 
   _onLevel2Update(msg, market) {
-    let channel = msg[0];
     let [price, count, size] = msg[1];
     let sequence = +msg[2];
 
@@ -270,7 +269,6 @@ class BitfinexClient extends BasicClient {
     let bids = [];
     let asks = [];
     
-    let channel = msg[0];
     let orders = msg[1];
     let sequence = +msg[2];
 
@@ -294,7 +292,6 @@ class BitfinexClient extends BasicClient {
     let bids = [];
     let asks = [];
     
-    let channel = msg[0];
     // let [price, count, size] = msg[1];
     let [orderId, price, size] = msg[1];
     let sequence = +msg[2];

--- a/src/exchanges/bitfinex-client.js
+++ b/src/exchanges/bitfinex-client.js
@@ -18,7 +18,6 @@ class BitfinexClient extends BasicClient {
     this.hasLevel2Updates = true;
     this.hasLevel3Updates = true;
     this.l2UpdateDepth = l2UpdateDepth;
-    this._connect();
   }
 
   _onConnected() {

--- a/src/exchanges/bitflyer-client.js
+++ b/src/exchanges/bitflyer-client.js
@@ -199,7 +199,6 @@ class BitFlyerClient extends BasicClient {
         let remote_id = market.id;
         let uri = `https://api.bitflyer.com/v1/board?product_code=${remote_id}`;
         let raw = await https.get(uri);
-        console.log('--snapshot raw=', raw);
         let asks = raw.asks.map(p => new Level2Point(p.price.toFixed(8), p.size.toFixed(8)));
         let bids = raw.bids.map(p => new Level2Point(p.price.toFixed(8), p.size.toFixed(8)));
         let snapshot = new Level2Snapshot({

--- a/src/exchanges/bitflyer-client.js
+++ b/src/exchanges/bitflyer-client.js
@@ -199,6 +199,7 @@ class BitFlyerClient extends BasicClient {
         let remote_id = market.id;
         let uri = `https://api.bitflyer.com/v1/board?product_code=${remote_id}`;
         let raw = await https.get(uri);
+        console.log('--snapshot raw=', raw);
         let asks = raw.asks.map(p => new Level2Point(p.price.toFixed(8), p.size.toFixed(8)));
         let bids = raw.bids.map(p => new Level2Point(p.price.toFixed(8), p.size.toFixed(8)));
         let snapshot = new Level2Snapshot({


### PR DESCRIPTION
for #236 

* update to v2 bitfinex websocket API
* add config call to get sequence IDs included in each message
* increase default book depth from 100 to 250