### PR TITLE
Gemini include l2 heartbeat event for sequenceId

### DIFF
--- a/__tests__/exchanges/gemini-client.spec.js
+++ b/__tests__/exchanges/gemini-client.spec.js
@@ -68,6 +68,11 @@ testClient({
   },
 
   l2update: {
+    done: function(spec, result, update, market) {
+      const hasAsks = update.asks && update.asks.length > 0;
+      const hasBids = update.bids && update.bids.length > 0;
+      return hasAsks || hasBids;
+    },
     hasSnapshot: true,
     hasTimestampMs: true,
     hasSequenceId: true,

--- a/src/exchanges/gemini-client.js
+++ b/src/exchanges/gemini-client.js
@@ -266,17 +266,14 @@ class GeminiClient extends EventEmitter {
         - Each time you reconnect, the sequence number resets to zero.
         - If you have multiple WebSocket connections, each will have a separate sequence number beginning with zero - make sure to keep track of each sequence number separately!
       */
-      if (subscription.level2Updates) {
+      if (subscription.level2updates) {
         /*
           So when subbed to l2 updates using sequenceId, a heartbeat event will arrive which includes sequenceId.
           You'll need to receive the heartbeat, otherwise sequence will have a gap in next l2update,
           So emit an l2update w/no ask or bid changes, only including the sequenceId
         */
         const sequenceId = msg.socket_sequence;
-        this.emit("l2update",
-          this._constructL2Update([], market, sequenceId, null, null),
-          market
-        );
+        this.emit("l2update", this._constructL2Update([], market, sequenceId, null, null), market);
         return;
       }
     }

--- a/src/exchanges/gemini-client.js
+++ b/src/exchanges/gemini-client.js
@@ -255,6 +255,18 @@ class GeminiClient extends EventEmitter {
 
     if (!market) return;
 
+    if (msg.type === "heartbeat") {
+      // if using sequenceId a heartbeat event will arrive which includes sequenceId.
+      // you'll need to receive heartbeat, otherwise sequence will have a gap in next l2update,
+      // so emit an l2update w/no ask or bid changes, only including the sequenceId
+      // ex: '{"type":"heartbeat","socket_sequence":272}'
+      const sequenceId = msg.socket_sequence;
+      this.emit("l2update",
+        this._constructL2Update([], market, sequenceId, null, null),
+        market
+      );
+      return;
+    }
     if (msg.type === "update") {
       let { timestampms, eventId, socket_sequence } = msg;
       const sequenceId = socket_sequence;
@@ -331,7 +343,6 @@ class GeminiClient extends EventEmitter {
       bids,
     });
   }
-
   _constructL2Update(events, market, sequenceId, timestampMs, eventId) {
     let asks = [];
     let bids = [];


### PR DESCRIPTION
@bmancini55 please lmk if you have any other ideas around this. You need access to the `sequenceId` in the heartbeat event to validate order book data, so I figured the easiest backwards-compatible solution was to just emit an `l2update` event without any ask or bids changes that only includes the `sequenceId`