### PR TITLE
Bitfinex handle heartbeat sequenceId

### DIFF
--- a/__tests__/exchanges/bitfinex-client.spec.js
+++ b/__tests__/exchanges/bitfinex-client.spec.js
@@ -69,6 +69,11 @@ testClient({
     hasTimestampMs: true,
     hasSequenceId: true,
     hasCount: true,
+    done: function(spec, result, update, market) {
+      const hasAsks = update.asks && update.asks.length > 0;
+      const hasBids = update.bids && update.bids.length > 0;
+      return hasAsks || hasBids;
+    },
   },
 
   l3snapshot: {
@@ -81,5 +86,10 @@ testClient({
     hasTimestampMs: true,
     hasSequenceId: true,
     hasCount: true,
+    done: function(spec, result, update, market) {
+      const hasAsks = update.asks && update.asks.length > 0;
+      const hasBids = update.bids && update.bids.length > 0;
+      return hasAsks || hasBids;
+    },
   },
 });


### PR DESCRIPTION
The hunt for 100% valid order books continues apparently. This is a similar update to the one I did for Gemini in #244. Sequence ID is shared across all channels and if you're subscribed to l2 or l3 book you need to receive the sequenceId of heartbeat events. For backwards compatibility I've just emitted an empty l2 or l3 update w/the sequenceId included from the heartbeat.