### PR TITLE
binance: use symbol@ticker instead of !ticker@arr

### DIFF
--- a/src/exchanges/binance-base.js
+++ b/src/exchanges/binance-base.js
@@ -44,7 +44,7 @@ class BinanceBase extends BasicClient {
     restThrottleMs = 1000,
     l2updateSpeed = "",
     l2snapshotSpeed = "",
-    batchTickers,
+    batchTickers = true,
   } = {}) {
     super(wssPath, name, undefined, watcherMs);
     this._restL2SnapshotPath = restL2SnapshotPath;

--- a/src/exchanges/binance-client.js
+++ b/src/exchanges/binance-client.js
@@ -10,6 +10,7 @@ class BinanceClient extends BinanceBase {
     watcherMs,
     l2updateSpeed,
     l2snapshotSpeed,
+    batchTickers = true,
   } = {}) {
     super({
       name: "Binance",
@@ -23,6 +24,7 @@ class BinanceClient extends BinanceBase {
       watcherMs,
       l2updateSpeed,
       l2snapshotSpeed,
+      batchTickers,
     });
   }
 }


### PR DESCRIPTION
I've modified Binance ticker stream to use `symbol@ticker` (single pair stream) instead of `!ticker@arr` (all pairs stream).

#279: I had issue when using the binance ticker. I was getting high peak of download (400KB/s) which was unnecessary when looking only at 1 pair