### PR TITLE
Add retryTimeoutMs param

### DIFF
--- a/src/BasicClient.ts
+++ b/src/BasicClient.ts
@@ -6,7 +6,7 @@ import { Watcher } from "./Watcher";
 import { Market } from "./Market";
 
 export type MarketMap = Map<string, Market>;
-export type WssFactoryFn = (path: string) => SmartWss;
+export type WssFactoryFn = (path: string, retryTimeoutMs?: number) => SmartWss;
 export type SendFn = (remoteId: string, market: Market) => void;
 
 /**
@@ -42,6 +42,7 @@ export abstract class BasicClient extends EventEmitter implements IClient {
         readonly name: string,
         wssFactory?: WssFactoryFn,
         watcherMs?: number,
+        retryTimeoutMs?: number,
     ) {
         super();
         this._tickerSubs = new Map();
@@ -61,7 +62,7 @@ export abstract class BasicClient extends EventEmitter implements IClient {
         this.hasLevel2Updates = false;
         this.hasLevel3Snapshots = false;
         this.hasLevel3Updates = false;
-        this._wssFactory = wssFactory || (path => new SmartWss(path));
+        this._wssFactory = wssFactory || (path => new SmartWss(path, retryTimeoutMs));
     }
 
     //////////////////////////////////////////////

--- a/src/ClientOptions.ts
+++ b/src/ClientOptions.ts
@@ -2,6 +2,7 @@ export type ClientOptions = {
     wssPath?: string;
     watcherMs?: number;
     throttleMs?: number;
+    retryTimeoutMs?: number;
     l2UpdateDepth?: number;
     throttleL2Snapshot?: number;
 };

--- a/src/SmartWss.ts
+++ b/src/SmartWss.ts
@@ -11,9 +11,9 @@ export class SmartWss extends EventEmitter {
     private _connected: boolean;
     private _wss: any;
 
-    constructor(readonly wssPath: string) {
+    constructor(readonly wssPath: string, retryTimeoutMs = 15000) {
         super();
-        this._retryTimeoutMs = 15000;
+        this._retryTimeoutMs = retryTimeoutMs;
         this._connected = false;
     }
 

--- a/src/exchanges/DigifinexClient.ts
+++ b/src/exchanges/DigifinexClient.ts
@@ -3,7 +3,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { setInterval } from "timers";
 import { BasicClient } from "../BasicClient";
 import { ClientOptions } from "../ClientOptions";
 import { Level2Point } from "../Level2Point";
@@ -20,7 +19,6 @@ import * as zlib from "../ZlibUtils";
  */
 export class DigifinexClient extends BasicClient {
     public id: number;
-    private _pingInterval: NodeJS.Timeout;
 
     constructor({ wssPath = "wss://openapi.digifinex.com/ws/v1/", watcherMs, retryTimeoutMs }: ClientOptions = {}) {
         super(wssPath, "Digifinex", undefined, watcherMs, retryTimeoutMs);
@@ -29,33 +27,6 @@ export class DigifinexClient extends BasicClient {
         this.hasLevel2Updates = true;
         this.id = 0;
         this._onMessageInf = this._onMessageInf.bind(this);
-    }
-
-    protected _beforeConnect() {
-        this._wss.on("connected", this._startPing.bind(this));
-        this._wss.on("disconnected", this._stopPing.bind(this));
-        this._wss.on("closed", this._stopPing.bind(this));
-    }
-
-    protected _startPing() {
-        clearInterval(this._pingInterval);
-        this._pingInterval = setInterval(this._sendPing.bind(this), 15000);
-    }
-
-    protected _stopPing() {
-        clearInterval(this._pingInterval);
-    }
-
-    protected _sendPing() {
-        if (this._wss) {
-            this._wss.send(
-                JSON.stringify({
-                    "id": Math.random() * (9999999999 - 1000000000) + 1000000000,
-                    "method": "server.ping",
-                    "params": []
-                })
-            )
-        }
     }
 
     protected _sendSubTicker(remote_id) {

--- a/src/exchanges/DigifinexClient.ts
+++ b/src/exchanges/DigifinexClient.ts
@@ -22,8 +22,8 @@ export class DigifinexClient extends BasicClient {
     public id: number;
     private _pingInterval: NodeJS.Timeout;
 
-    constructor({ wssPath = "wss://openapi.digifinex.com/ws/v1/", watcherMs }: ClientOptions = {}) {
-        super(wssPath, "Digifinex", undefined, watcherMs);
+    constructor({ wssPath = "wss://openapi.digifinex.com/ws/v1/", watcherMs, retryTimeoutMs }: ClientOptions = {}) {
+        super(wssPath, "Digifinex", undefined, watcherMs, retryTimeoutMs);
         this.hasTickers = true;
         this.hasTrades = true;
         this.hasLevel2Updates = true;

--- a/src/exchanges/DigifinexClient.ts
+++ b/src/exchanges/DigifinexClient.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { setInterval } from "timers";
 import { BasicClient } from "../BasicClient";
 import { ClientOptions } from "../ClientOptions";
 import { Level2Point } from "../Level2Point";
@@ -19,6 +20,7 @@ import * as zlib from "../ZlibUtils";
  */
 export class DigifinexClient extends BasicClient {
     public id: number;
+    private _pingInterval: NodeJS.Timeout;
 
     constructor({ wssPath = "wss://openapi.digifinex.com/ws/v1/", watcherMs }: ClientOptions = {}) {
         super(wssPath, "Digifinex", undefined, watcherMs);
@@ -27,6 +29,33 @@ export class DigifinexClient extends BasicClient {
         this.hasLevel2Updates = true;
         this.id = 0;
         this._onMessageInf = this._onMessageInf.bind(this);
+    }
+
+    protected _beforeConnect() {
+        this._wss.on("connected", this._startPing.bind(this));
+        this._wss.on("disconnected", this._stopPing.bind(this));
+        this._wss.on("closed", this._stopPing.bind(this));
+    }
+
+    protected _startPing() {
+        clearInterval(this._pingInterval);
+        this._pingInterval = setInterval(this._sendPing.bind(this), 15000);
+    }
+
+    protected _stopPing() {
+        clearInterval(this._pingInterval);
+    }
+
+    protected _sendPing() {
+        if (this._wss) {
+            this._wss.send(
+                JSON.stringify({
+                    "id": Math.random() * (9999999999 - 1000000000) + 1000000000,
+                    "method": "server.ping",
+                    "params": []
+                })
+            )
+        }
     }
 
     protected _sendSubTicker(remote_id) {


### PR DESCRIPTION
Changes for #316 

This will allow to reconnect the websocket after its connection is lost.
Currently there's a hardcoded value of _retryTimeoutMs=15000ms, this value is kept as a default, but now, classes that inherit BasicClient can get a retryTimeoutMs parameter that will be used in SmartWss.

Currently only tested on DigifinexClient