### PR TITLE
Add token permissions for node.yml

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -5,8 +5,14 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
+    permissions:
+      checks: write  # for coverallsapp/github-action to create new checks
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -42,6 +48,9 @@ jobs:
           parallel: true
 
   exchange:
+    permissions:
+      checks: write  # for coverallsapp/github-action to create new checks
+      contents: read  # for actions/checkout to fetch code
     needs: [validate]
     runs-on: ubuntu-latest
     strategy:
@@ -107,6 +116,8 @@ jobs:
           parallel: true
 
   finish:
+    permissions:
+      checks: write  # for coverallsapp/github-action to create new checks
     needs: [validate, exchange]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
GitHub asks users to define workflow permissions, see https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token for securing GitHub workflows against supply-chain attacks.

The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. 

This repository has a Scorecards score of 3/10 with 10 being the most secure. The `Token-Permissions` category has a score of 0/10.

This file was fixed automatically using the open-source tool https://github.com/step-security/secure-workflows. If you like the changes and merge them, please consider starring the repo. 